### PR TITLE
Fix: Resolve unwanted scrollbar in sidepanel using CSS Grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,12 @@
+html {
+    height: 100%;
+}
+
 body {
     font-family: sans-serif;
-    margin: 20px;
+    margin: 0; /* MODIFIED - was 20px */
     background-color: #f4f4f4;
+    height: 100%; /* ADDED/MODIFIED */
 }
 
 h1, h2 {
@@ -47,9 +52,9 @@ h1, h2 {
 
 /* Side Panel Specific Styles */
 .sidepanel-container {
-    display: flex;
-    flex-direction: column;
-    height: 100vh; /* Full height of the side panel */
+    display: grid;
+    grid-template-rows: auto 1fr auto; /* Header, main content (responseArea), footer */
+    height: 100%; /* MODIFIED - was 100vh */
     padding: 10px;
     box-sizing: border-box;
 }
@@ -79,13 +84,13 @@ h1, h2 {
 }
 
 #responseArea {
-    flex-grow: 1; /* Takes up available space */
-    overflow-y: auto; /* Scrollable */
+    overflow-y: auto; /* Scrollable - ensure this remains */
     padding: 10px;
     background-color: #fff;
     border: 1px solid #ddd;
     border-radius: 4px;
     margin-bottom: 10px;
+    min-height: 0; /* ADDED */
 }
 
 #responseArea .user-message, #responseArea .ai-message, #responseArea .error-message, .welcome-message {


### PR DESCRIPTION
The sidepanel previously used `height: 100vh` and flexbox, which, in combination with padding, caused an unwanted scrollbar on the main container.

This commit refactors the sidepanel layout to use CSS Grid:
- `html` and `body` tags are set to `height: 100%` with `body margin: 0` to ensure the body correctly fills the viewport.
- `.sidepanel-container` is changed to `display: grid` with `grid-template-rows: auto 1fr auto` (for header, content, footer). Its height is set to `100%` to fill the modified body.
- `#responseArea` (the content area) now uses `min-height: 0` to ensure correct scrolling behavior within the grid row, which is set to `1fr` to take up remaining space.
- The `overflow-y: auto` on `#responseArea` now correctly manages scrolling for its content only.

This ensures that the header and footer remain fixed, and only the content area scrolls when its content exceeds the available space, eliminating the scrollbar on the main sidepanel container.